### PR TITLE
Improve swift build error features

### DIFF
--- a/Sources/HaCWebsiteLib/ViewModels/LandingPage.swift
+++ b/Sources/HaCWebsiteLib/ViewModels/LandingPage.swift
@@ -174,7 +174,7 @@ struct LandingPage {
               )
             )
           )
-        ) 
+        )
       )
     )
   }

--- a/Sources/HaCWebsiteLib/views/base.swift
+++ b/Sources/HaCWebsiteLib/views/base.swift
@@ -11,8 +11,8 @@ extension UI.Pages {
   static func base(title: String = defaultTitle, content: Node) -> Node {
     let error: Node
     let errorData: Data? = try? Data(contentsOf: URL(fileURLWithPath: "swift_build.log"))
-    if let outputData = errorData { 
-	error = Fragment(
+    if let outputData = errorData {
+      error = Fragment(
         El.P[Attr.className => "Error"].containing(String(data: outputData, encoding: String.Encoding.utf8) as String!)
       )
     } else {
@@ -26,9 +26,9 @@ extension UI.Pages {
           El.Meta[Attr.charset => "UTF-8"],
           El.Meta[Attr.name => "viewport", Attr.content => "width=device-width, initial-scale=1"],
           El.Link[Attr.rel => "icon", Attr.type => "favicon/png", Attr.href => "/static/images/favicon.png"],
-	  El.Title.containing(TextNode(title)),
-          stylesheet(forUrl: "/static/styles/main.css")
-        ),
+          El.Title.containing(TextNode(title)),
+            stylesheet(forUrl: "/static/styles/main.css")
+          ),
         El.Body.containing(error, content)
       )
     )

--- a/Sources/HaCWebsiteLib/views/base.swift
+++ b/Sources/HaCWebsiteLib/views/base.swift
@@ -13,7 +13,9 @@ extension UI.Pages {
     let errorData: Data? = try? Data(contentsOf: URL(fileURLWithPath: "swift_build.log"))
     if let outputData = errorData {
       error = Fragment(
-        El.P[Attr.className => "Error"].containing(String(data: outputData, encoding: String.Encoding.utf8) as String!)
+        El.Pre.containing(
+          El.Code[Attr.className => "BuildOutput__Error"].containing(String(data: outputData, encoding: String.Encoding.utf8) as String!)
+        )
       )
     } else {
       error = Fragment(El.Div)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,24 +57,24 @@ function connectProcessOutput (process, prefix) {
 // Runs the `swift build` command
 function swiftBuild (done) {
   var stream = fs.createWriteStream("swift_build.log");
-  
+
   stream.once('open', function(fd) {
     const buildProcess = childProcesses.spawn('swift', ['build'])
-    
+
     buildProcess.stdout.on('data', data => {
       stream.write(data);
     });
     buildProcess.stderr.on('data', data => {
       stream.write(data);
     });
-	
+
     const logPrefix = 'swift-build'
     connectProcessOutput(buildProcess, logPrefix)
     buildProcess.on('exit', function (code) {
       stream.end();
       if (code === 0) {
         fs.unlink("swift_build.log");
-	done()
+        done()
       } else {
         // The build failed
         // Ring the console 'bell'

--- a/static/src/styles/build/BuildOutput.styl
+++ b/static/src/styles/build/BuildOutput.styl
@@ -1,0 +1,7 @@
+.BuildOutput__Error {
+  // white-space: pre-line;
+  background-color: #000;
+  color: #595;
+  font-family: "Lucida Console", Monaco, monospace;
+  display: block;
+}

--- a/static/src/styles/build/index.styl
+++ b/static/src/styles/build/index.styl
@@ -1,0 +1,1 @@
+@require './BuildOutput';

--- a/static/src/styles/main.styl
+++ b/static/src/styles/main.styl
@@ -1,4 +1,5 @@
 @require './core';
+@require './build';
 @require './landing';
 @require './PostCard';
 @require './NotFound';


### PR DESCRIPTION
For pull request hackersatcambridge/hac-website#90, fixes indentation issues and makes the output of the errors easier to read:

![screenshot from 2017-10-16 20-14-57](https://user-images.githubusercontent.com/10348641/31630526-badaf048-b2ae-11e7-8e87-b17165f1f920.png)
